### PR TITLE
Fix documentation and fix order of merge params

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin will upload all built assets to s3
 ```bash
 $ npm i webpack-s3-plugin
 ```
+Note: This plugin needs NodeJS > 0.12.0
 
 ### Usage Instructions
 
@@ -28,13 +29,13 @@ var config = {
       s3Options: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        region: 'us-west-1'
       },
       s3UploadOptions: {
-        Bucket: 'MyBucket',
-        region: 'us-west-1' 
+        Bucket: 'MyBucket'
       },
       cdnizerConfig: {
-        defaultCDNBase: 'http://asdf.ca'  
+        defaultCDNBase: 'http://asdf.ca'
       }
     })
   ]

--- a/dist/s3_plugin.js
+++ b/dist/s3_plugin.js
@@ -88,7 +88,7 @@ var S3Plugin = (function () {
 
     this.clientConfig = {
       maxAsyncS3: 50,
-      s3Options: _lodash2['default'].merge(s3Options, DEFAULT_S3_OPTIONS)
+      s3Options: _lodash2['default'].merge(DEFAULT_S3_OPTIONS, s3Options)
     };
 
     if (!this.cdnizerOptions.files) this.cdnizerOptions.files = [];
@@ -188,7 +188,8 @@ var S3Plugin = (function () {
       var htmlFiles = _options.htmlFiles;
 
       var allHtml = (htmlFiles || _fs2['default'].readdirSync(directory).filter(function (file) {
-        return /\.html$/.test(file);
+        return (/\.html$/.test(file)
+        );
       })).map(function (file) {
         return _path2['default'].resolve(directory, file);
       });

--- a/package.json
+++ b/package.json
@@ -26,8 +26,12 @@
   },
   "homepage": "https://github.com/MikaAK/s3-plugin-webpack",
   "dependencies": {
+    "s3": "^4.4.0",
     "cdnizer": "^1.1.5",
     "lodash": "^3.10.1",
     "progress": "^1.1.8"
+  },
+  "devDependencies": {
+    "babel": "^5.8.21"
   }
 }

--- a/src/s3_plugin.js
+++ b/src/s3_plugin.js
@@ -34,15 +34,15 @@ export default class S3Plugin {
     this.uploadProgress = 0
 
     this.options = {
-      directory, 
-      include, 
-      exclude, 
+      directory,
+      include,
+      exclude,
       htmlFiles: typeof htmlFiles === 'string' ? [htmlFiles] : htmlFiles
     }
 
     this.clientConfig = {
       maxAsyncS3: 50,
-      s3Options: _.merge(s3Options, DEFAULT_S3_OPTIONS)
+      s3Options: _.merge(DEFAULT_S3_OPTIONS, s3Options)
     }
 
     if (!this.cdnizerOptions.files)


### PR DESCRIPTION
I had some issue with the plugin:
- region must be in `s3Options`, not in `s3UploadOptions`
- Miss dependency on `s3`
- s3Options is not merge in the right order: `DEFAULT_S3_OPTIONS` erase `region` value in `s3Options`
- This plugin doesn't work with NodeJS 0.10.x Just added a note.