### PR TITLE
Add aws-sdk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/MikaAK/s3-plugin-webpack",
   "dependencies": {
+    "aws-sdk": "~2.0.31",
     "cdnizer": "^1.1.5",
     "lodash": "^3.10.1",
     "progress": "^1.1.8",


### PR DESCRIPTION
The cloudfront invalidation has a dependency on aws, but it isn't listed as an explicit dependency. In a clean environment, the plugin will fail to find the aws module.