### PR TITLE
Use path instead of publicPath in getAssetFiles

### DIFF
--- a/dist/s3_plugin.js
+++ b/dist/s3_plugin.js
@@ -227,10 +227,10 @@ module.exports = (function () {
       var chunks = _ref.chunks;
       var options = _ref.options;
 
-      var publicPath = options.output.publicPath || options.output.path;
+      var outputPath = options.output.path || options.output.publicPath;
 
       var files = (0, _lodash2.default)(chunks).pluck('files').flatten().map(function (name) {
-        return { path: _path2.default.resolve(publicPath, name), name: name };
+        return { path: _path2.default.resolve(outputPath, name), name: name };
       }).value();
 
       return this.filterAllowedFiles(files);

--- a/src/s3_plugin.js
+++ b/src/s3_plugin.js
@@ -165,12 +165,12 @@ module.exports = class S3Plugin {
   }
 
   getAssetFiles({chunks, options}) {
-    var publicPath = options.output.publicPath || options.output.path
+    var outputPath = options.output.path || options.output.publicPath
 
     var files = _(chunks)
       .pluck('files')
       .flatten()
-      .map(name => ({path: path.resolve(publicPath, name), name}))
+      .map(name => ({path: path.resolve(outputPath, name), name}))
       .value()
 
     return this.filterAllowedFiles(files)


### PR DESCRIPTION
In the `getAssetFiles` function, `publicPath` takes precedence over `path`, but webpack places compiled files in the `path` directory.  `publicPath` is only used when serving files from the browser. This was generating errors in my build process because it could not find the compiled bundle.

It works fine if we reverse the precedence though.