### PR TITLE
New features: set gzip encoding for files, set the s3 website "index document" and cloudfront "root object"

### DIFF
--- a/dist/s3_plugin.js
+++ b/dist/s3_plugin.js
@@ -133,12 +133,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var indexOptions = _options$indexOptions === undefined ? {} : _options$indexOptions;
 	    var _options$gzipOptions = options.gzipOptions;
 	    var gzipOptions = _options$gzipOptions === undefined ? {} : _options$gzipOptions;
+	    var _options$cacheOptions = options.cacheOptions;
+	    var cacheOptions = _options$cacheOptions === undefined ? {} : _options$cacheOptions;
 
 
 	    this.uploadOptions = s3UploadOptions;
 	    this.cloudfrontInvalidateOptions = cloudfrontInvalidateOptions;
 	    this.indexOptions = indexOptions;
 	    this.gzipOptions = gzipOptions;
+	    this.cacheOptions = cacheOptions;
 	    this.isConnected = false;
 	    this.cdnizerOptions = cdnizerOptions;
 	    this.urlMappings = [];
@@ -453,6 +456,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	        if (this.gzipOptions.test.test(fileName)) s3Params.ContentEncoding = 'gzip';
 	      }
 
+	      if (this.cacheOptions.cacheControl) {
+	        s3Params.CacheControl = this.cacheOptions.cacheControl;
+	      }
+
 	      upload = this.client.uploadFile({
 	        localFile: file,
 	        s3Params: s3Params
@@ -504,7 +511,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	  }, {
 	    key: 'setCloudfrontIndex',
-	    value: function setCloudfrontIndex(clientConfig, cloudfrontInvalidateOptions, indexOptions) {
+	    value: function setCloudfrontIndex(clientConfig, indexOptions) {
 	      return new Promise(function (resolve, reject) {
 	        // Setup Cloudfront
 	        var cloudfront = new _awsSdk2.default.CloudFront();
@@ -515,7 +522,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	        // Get the existing distribution
 	        cloudfront.getDistribution({
-	          Id: cloudfrontInvalidateOptions.DistributionId
+	          Id: indexOptions.DistributionId
 	        }, function (err, data) {
 	          if (err) {
 	            reject(err);
@@ -529,7 +536,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	            cloudfront.updateDistribution({
 	              IfMatch: data.ETag,
-	              Id: cloudfrontInvalidateOptions.DistributionId,
+	              Id: indexOptions.DistributionId,
 	              DistributionConfig: data.DistributionConfig
 	            }, function (err, data) {
 	              if (err) {
@@ -601,7 +608,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var promises = [];
 	        // Cloudfront Index
 	        if (indexOptions.cloudfront) {
-	          promises.push(self.setCloudfrontIndex(clientConfig, cloudfrontInvalidateOptions, indexOptions));
+	          promises.push(self.setCloudfrontIndex(clientConfig, indexOptions));
 	        }
 	        // S3 Index
 	        if (indexOptions.s3) {

--- a/dist/s3_plugin.js
+++ b/dist/s3_plugin.js
@@ -503,6 +503,89 @@ return /******/ (function(modules) { // webpackBootstrap
 	      });
 	    }
 	  }, {
+	    key: 'setCloudfrontIndex',
+	    value: function setCloudfrontIndex(clientConfig, cloudfrontInvalidateOptions, indexOptions) {
+	      return new Promise(function (resolve, reject) {
+	        // Setup Cloudfront
+	        var cloudfront = new _awsSdk2.default.CloudFront();
+	        cloudfront.config.update({
+	          accessKeyId: clientConfig.s3Options.accessKeyId,
+	          secretAccessKey: clientConfig.s3Options.secretAccessKey
+	        });
+
+	        // Get the existing distribution
+	        cloudfront.getDistribution({
+	          Id: cloudfrontInvalidateOptions.DistributionId
+	        }, function (err, data) {
+	          if (err) {
+	            reject(err);
+	          } else {
+	            if (data.DistributionConfig.DefaultRootObject === indexOptions.IndexDocument) {
+	              resolve();
+	            }
+
+	            // Update the distribution with the new default root object
+	            data.DistributionConfig.DefaultRootObject = indexOptions.IndexDocument;
+
+	            cloudfront.updateDistribution({
+	              IfMatch: data.ETag,
+	              Id: cloudfrontInvalidateOptions.DistributionId,
+	              DistributionConfig: data.DistributionConfig
+	            }, function (err, data) {
+	              if (err) {
+	                reject(err);
+	              } else {
+	                resolve();
+	              }
+	            });
+	          }
+	        });
+	      });
+	    }
+	  }, {
+	    key: 'setS3Index',
+	    value: function setS3Index(clientConfig, uploadOptions, indexOptions) {
+	      return new Promise(function (resolve, reject) {
+	        var s3Client = new _awsSdk2.default.S3({
+	          params: {
+	            Bucket: uploadOptions.Bucket
+	          },
+	          accessKeyId: clientConfig.s3Options.accessKeyId,
+	          secretAccessKey: clientConfig.s3Options.secretAccessKey,
+	          region: clientConfig.s3Options.region
+	        });
+	        s3Client.getBucketWebsite({}, function (err, data) {
+	          if (err) {
+	            reject(err);
+	          } else {
+	            if (data.IndexDocument.Suffix === indexOptions.IndexDocument) {
+	              resolve();
+	            }
+
+	            // Update the distribution with the new default root object
+	            data.IndexDocument.Suffix = indexOptions.IndexDocument;
+
+	            //Remove empty properties
+	            Object.keys(data).forEach(function (k) {
+	              if (!data[k] || Array.isArray(data[k]) && !data[k].length) {
+	                delete data[k];
+	              }
+	            });
+
+	            s3Client.putBucketWebsite({
+	              WebsiteConfiguration: data
+	            }, function (err) {
+	              if (err) {
+	                reject(err);
+	              } else {
+	                resolve();
+	              }
+	            });
+	          }
+	        });
+	      });
+	    }
+	  }, {
 	    key: 'setIndex',
 	    value: function setIndex() {
 	      var clientConfig = this.clientConfig;
@@ -512,89 +595,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var client = this.client;
 
 
-	      return new Promise(function (resolve, reject) {
-	        if (indexOptions.IndexDocument) {
+	      var self = this;
 
-	          // Cloudfront Index
-	          if (indexOptions.cloudfront) {
-	            var cloudfront = new _awsSdk2.default.CloudFront();
-
-	            cloudfront.config.update({
-	              accessKeyId: clientConfig.s3Options.accessKeyId,
-	              secretAccessKey: clientConfig.s3Options.secretAccessKey
-	            });
-
-	            // Get the existing distribution id
-	            cloudfront.getDistribution({ Id: cloudfrontInvalidateOptions.DistributionId }, function (err, data) {
-	              if (err) {
-	                reject(err);
-	              } else {
-	                if (data.DistributionConfig.DefaultRootObject === indexOptions.IndexDocument) {
-	                  return resolve();
-	                }
-
-	                // Update the distribution with the new default root object
-	                data.DistributionConfig.DefaultRootObject = indexOptions.IndexDocument;
-
-	                cloudfront.updateDistribution({
-	                  IfMatch: data.ETag,
-	                  Id: cloudfrontInvalidateOptions.DistributionId,
-	                  DistributionConfig: data.DistributionConfig
-	                }, function (err, data) {
-	                  if (err) {
-	                    reject(err);
-	                  } else {
-	                    resolve();
-	                  }
-	                });
-	              }
-	            });
-	          }
-	          // S3 Index
-	          if (indexOptions.s3) {
-	            // AWS.config.region = options.region;
-	            var s3Client = new _awsSdk2.default.S3({
-	              params: {
-	                Bucket: uploadOptions.Bucket
-	              },
-	              accessKeyId: clientConfig.s3Options.accessKeyId,
-	              secretAccessKey: clientConfig.s3Options.secretAccessKey,
-	              region: clientConfig.s3Options.region
-	            });
-	            s3Client.getBucketWebsite({}, function (err, data) {
-	              if (err) {
-	                reject(err);
-	              } else {
-	                if (data.IndexDocument.Suffix === indexOptions.IndexDocument) {
-	                  return resolve();
-	                }
-
-	                // Update the distribution with the new default root object
-	                data.IndexDocument.Suffix = indexOptions.IndexDocument;
-
-	                //Remove empty properties
-	                Object.keys(data).forEach(function (k) {
-	                  if (!data[k] || Array.isArray(data[k]) && !data[k].length) {
-	                    delete data[k];
-	                  }
-	                });
-
-	                s3Client.putBucketWebsite({
-	                  WebsiteConfiguration: data
-	                }, function (err) {
-	                  if (err) {
-	                    reject(err);
-	                  } else {
-	                    resolve();
-	                  }
-	                });
-	              }
-	            });
-	          }
-	        } else {
-	          return resolve(null);
+	      if (indexOptions.IndexDocument) {
+	        var promises = [];
+	        // Cloudfront Index
+	        if (indexOptions.cloudfront) {
+	          promises.push(self.setCloudfrontIndex(clientConfig, cloudfrontInvalidateOptions, indexOptions));
 	        }
-	      });
+	        // S3 Index
+	        if (indexOptions.s3) {
+	          promises.push(self.setS3Index(clientConfig, uploadOptions, indexOptions));
+	        }
+
+	        return Promise.all(promises);
+	      } else {
+	        return Promise.resolve();
+	      }
 	    }
 	  }]);
 

--- a/test/s3_options.js
+++ b/test/s3_options.js
@@ -30,5 +30,11 @@ export default {
   cloudfrontInvalidateOptions: {
     DistributionId: CLOUDFRONT_DISTRIBUTION_ID,
     Items: ['/*']
-  }
+  },
+
+  indexOptions: {
+    IndexDocument: 'index.123.html',
+    s3: true,
+    cloudfront: true,
+  },
 }

--- a/test/upload_test.js
+++ b/test/upload_test.js
@@ -138,6 +138,27 @@ describe('S3 Webpack Upload', function() {
       .then(randomFileBody => assert.match(randomFileBody, testHelpers.S3_ERROR_REGEX, 'random file exists'))
   })
 
+  it('starts a index change', function() {
+    var config,
+        randomFile
+
+    var s3Config = {
+      indexOptions: testHelpers.getIndexOptions(),
+      cloudfrontInvalidateOptions: testHelpers.getCloudfrontInvalidateOptions()
+    }
+
+    config = testHelpers.createWebpackConfig({s3Config})
+
+    testHelpers.createOutputPath()
+    randomFile = testHelpers.createRandomFile(testHelpers.OUTPUT_PATH)
+
+    return testHelpers.runWebpackConfig({config})
+      .then(testForFailFromStatsOrGetS3Files)
+      .then(assertFileMatches)
+      .then(() => testHelpers.fetch(testHelpers.S3_URL + randomFile.fileName))
+      .then(randomFileBody => assert.match(randomFileBody, testHelpers.S3_ERROR_REGEX, 'random file exists'))
+  })
+
   it('excludes files from `exclude` property', function() {
     testHelpers.createOutputPath()
 

--- a/test/upload_test_helpers.js
+++ b/test/upload_test_helpers.js
@@ -194,5 +194,9 @@ export default {
 
   getCloudfrontInvalidateOptions() {
     return s3Opts.cloudfrontInvalidateOptions
+  },
+
+  getIndexOptions() {
+    return s3Opts.indexOptions
   }
 }


### PR DESCRIPTION
This pullrequest allows you to do 2 things:

1. You can provide a test regex to set the Content-Encoding to "gzip" for files that you already gzipped.
I am using this in combination with https://github.com/webpack/compression-webpack-plugin
You can add the following to the config:
```
gzipOptions: {
  test: /\.(js|css)$/,
},
```
2. You can provide a name for your index document in s3 and root object in cloudfront.
This allows you to add a hash to your index.html filename like (index.diu32dk.html) for cache busting.
I am using this in combination with https://www.npmjs.com/package/html-webpack-plugin
You can add the following to the config:
```
indexOptions: {
  IndexDocument: `index.${GIT_VERSION}.html`,
  s3: true,
  cloudfront: true,
},
````

I would love feedback on this pullrequest and can make changes if needed. I'm not sure if the tests are enough and if this should maybe be split into 2 pullrequests.
Let me know what I can do to get this merged and if it's not out of scope for this plugin.
