### PR TITLE
Allow to pass callbacks to configure any option in s3UploadOptions

### DIFF
--- a/dist/s3_plugin.js
+++ b/dist/s3_plugin.js
@@ -441,6 +441,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // Remove Gzip from encoding if ico
 	      if (/\.ico/.test(fileName) && s3Params.ContentEncoding === 'gzip') delete s3Params.ContentEncoding;
 
+	      _lodash2.default.forEach(s3Params, function (value, key) {
+	        if (_lodash2.default.isFunction(value)) {
+	          s3Params[key] = value(fileName, file);
+	        }
+	      });
+
 	      upload = this.client.uploadFile({
 	        localFile: file,
 	        s3Params: s3Params

--- a/src/s3_plugin.js
+++ b/src/s3_plugin.js
@@ -271,6 +271,12 @@ module.exports = class S3Plugin {
     if (/\.ico/.test(fileName) && s3Params.ContentEncoding === 'gzip')
       delete s3Params.ContentEncoding
 
+    _.forEach(s3Params, (value, key) => {
+      if (_.isFunction(value)) {
+        s3Params[key] = value(fileName, file)
+      }
+    })
+
     upload = this.client.uploadFile({
       localFile: file,
       s3Params


### PR DESCRIPTION
I'm using this to configure gzipped assets. Instead of hardcoding I thought it could be useful to allow configuring any option based on the asset name/path.

```javascript
new S3Plugin({
  ...
  s3UploadOptions: {
    ...
    ContentEncoding: function(fileName) {
      if (/\.gz$/.test(fileName)) {
        return 'gzip';
      }
    },
    ContentType: function(fileName) {
      if (/\.css(\.gz)?$/.test(fileName)) {
        return 'text/css';
      }

      if (/\.js(\.gz)?$/.test(fileName)) {
        return 'application/javascript';
      }
    }
  }
})
```