### PR TITLE
Remove checking AWS credentials

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,7 +14,6 @@ export const DEFAULT_S3_OPTIONS = {
   region: 'us-west-2'
 }
 
-export const REQUIRED_S3_OPTS = ['accessKeyId', 'secretAccessKey']
 export const REQUIRED_S3_UP_OPTS = ['Bucket']
 export const PATH_SEP = path.sep
 export const S3_PATH_SEP = '/'

--- a/src/s3_plugin.js
+++ b/src/s3_plugin.js
@@ -15,7 +15,6 @@ import {
   UPLOAD_IGNORES,
   DEFAULT_UPLOAD_OPTIONS,
   DEFAULT_S3_OPTIONS,
-  REQUIRED_S3_OPTS,
   REQUIRED_S3_UP_OPTS,
   PATH_SEP,
   DEFAULT_TRANSFORM,
@@ -77,7 +76,6 @@ module.exports = class S3Plugin {
     this.connect()
 
     const isDirectoryUpload = !!this.options.directory,
-          hasRequiredOptions = this.client.s3.config.credentials !== null,
           hasRequiredUploadOpts = _.every(REQUIRED_S3_UP_OPTS, type => this.uploadOptions[type])
 
     // Set directory to output dir or custom
@@ -88,9 +86,6 @@ module.exports = class S3Plugin {
 
     compiler.plugin('after-emit', (compilation, cb) => {
       var error
-
-      if (!hasRequiredOptions)
-        error = `S3Plugin: Must provide ${REQUIRED_S3_OPTS.join(', ')}`
 
       if (!hasRequiredUploadOpts)
         error = `S3Plugin-RequiredS3UploadOpts: ${REQUIRED_S3_UP_OPTS.join(', ')}`


### PR DESCRIPTION
@MikaAK 
Hi, thank you for sharing the useful OSS 😃 

I want to run this plugin on an EC2 instance. In the situation, we don't need to set accessKeyId and secretAccessKey because the instance has `instance profile credentials`. So I'd like to remove the assertion.

What do you think?