### PR TITLE
chore(packages): Update s3 to point at master

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.13.0",
     "progress": "^1.1.8",
     "recursive-readdir": "^2.0.0",
-    "s3": "^4.4.0"
+    "s3": "git+https://github.com/andrewrk/node-s3-client.git#master"
   },
   "devDependencies": {
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
s3 is a dead project, this needs to be switched over to use aws sdk directly since we already use it for cloudfront. This will temporarily unblock #43 until that point