### PR TITLE
Support CodeBuild/ECR

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/webpack-contrib/s3-plugin-webpack",
   "dependencies": {
-    "aws-sdk": "^2.4.1",
+    "aws-sdk": "^2.213.1",
     "cdnizer": "^1.1.5",
     "lodash": "^4.13.0",
     "progress": "^1.1.8",


### PR DESCRIPTION
AWS CodeBuild uses ECR under the hood. Instance roles are passed in differently to containers in ECR. Instead of being available on 169.254.169.254, they are available on 169.254.170.2 in a different format. The old AWS SDK that was used doesn't know how to read the instance role from there. This commit fixes the issue by upgrading to a newer AWS SDK that is aware of the new ECR metadata server and therefore works in CodeBuild.