### PR TITLE
Support root-relative urls

### DIFF
--- a/src/s3_plugin.js
+++ b/src/s3_plugin.js
@@ -173,7 +173,7 @@ module.exports = class S3Plugin {
     else
       allHtml = files
 
-    this.cdnizerOptions.files = allHtml.map(({name}) => `*${name}*`)
+    this.cdnizerOptions.files = allHtml.map(({name}) => `{/,}*${name}*`)
     this.cdnizer = cdnizer(this.cdnizerOptions)
 
     const [cdnizeFiles, otherFiles] = _(allHtml)


### PR DESCRIPTION
Context
===
in my application, `link` and `script` tags *MUST* use root-relative paths (such as `/a/b/c/my-code.js`) instead of relative paths (`a/b/c/my-code.js` -- no leading forward slash).

Currently, this plugin does nothing when the paths are root-relative. This is because [`minimatch`](https://github.com/isaacs/minimatch/tree/master) (The lib used to parse the glob patterns) is matching the path `/a/b/c/my-code.js` against a glob that is `*a/b/c/my-code.js` and returning `false`.

Solution
===
Create a more flexible `glob` that accepts a conditional leading `/` 