### PR TITLE
Change the webpack trigger

### DIFF
--- a/src/s3_plugin.js
+++ b/src/s3_plugin.js
@@ -88,7 +88,7 @@ module.exports = class S3Plugin {
                              compiler.options.output.context ||
                              '.'
 
-    compiler.hooks.afterEmit.tapPromise(packageJson.name, async(compilation) => {
+    compiler.hooks.done.tapPromise(packageJson.name, async(compilation) => {
       var error
 
       if (!hasRequiredUploadOpts)


### PR DESCRIPTION
Change the webpack event that triggers the S3 upload. This should allow for assets generated by 'non-webpack' scripts in the webpack build process to also be included in the upload. This also fixes an issue for people that use this plugin with Laravel Mix.