### PR TITLE
bump minimum node-version to 14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,9 +15,10 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10
-          - 12
           - 14
+          - 16
+          - 18
+          - 20
         command:
           - lint
           - test


### PR DESCRIPTION
should fix failing build or uncover next errors
>error @aws-sdk/abort-controller@3.295.0: The engine "node" is incompatible with this module. Expected version ">=14.0.0". Got "10.24.1"